### PR TITLE
fix: Reset editor state when initialising a new note to ensure clean reinitialization

### DIFF
--- a/client/views/Note.vue
+++ b/client/views/Note.vue
@@ -123,7 +123,7 @@ import { mdiNoteOffOutline } from "@mdi/js";
 import { mdilContentSave, mdilDelete } from "@mdi/light-js";
 import Mousetrap from "mousetrap";
 import { useToast } from "primevue/usetoast";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch} from "vue";
 import { useRouter } from "vue-router";
 
 import {
@@ -192,8 +192,14 @@ function init() {
   } else {
     newTitle.value = "";
     note.value = new Note();
-    editHandler();
-    loadingIndicator.value.setLoaded();
+    // Set the editMode to false to close any existing editors.
+    // This ensures the editor is cleanly reinitialised in an empty state.
+    // Simple fix for #266 without requiring a full re-work of the logic.
+    editMode.value = false;
+    nextTick(() => {
+      editHandler();
+      loadingIndicator.value.setLoaded();
+    });
   }
 }
 


### PR DESCRIPTION
Porting from https://github.com/dullage/flatnotes/commit/d0564a43f8ea05202de3c17afb7b6ba8d3fb8a43#diff-8f659906d209d74fa567ce2623184c40d23c877239d567e55d48e37d5858d6aaR128